### PR TITLE
Max listeners

### DIFF
--- a/lib/fliclibNodeJs.js
+++ b/lib/fliclibNodeJs.js
@@ -576,6 +576,8 @@ var FlicClient = function(host, port) {
 	
 	var getInfoResponseCallbackQueue = [];
 	
+	this.setMaxListeners(Infinity);
+	
 	rawClient.onOpen = function() {
 		me.emit("ready");
 	};


### PR DESCRIPTION
If more than 10 node-red-contrib-flib-buttons nodes are added, this warning will be logged on every deploy:
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 ready listeners added. Use emitter.setMaxListeners() to increase limit
```

This PR fixes the issue by increasing EventEmitter max listeners limit.

Note: My editor removes trailing white space by default. If that is an issue, let me know and I'll fix the PR.